### PR TITLE
fix: ensure cache directory exists before torch.save to avoid Runtime…

### DIFF
--- a/utils/image_utils_flux.py
+++ b/utils/image_utils_flux.py
@@ -1164,6 +1164,7 @@ def create_empty_embedding(tokenizers,text_encoders,cache_path="cache/empty_embe
         # "time_id":time_id.cpu()
     }
     # save latent to cache file
+    os.makedirs(os.path.dirname(cache_path), exist_ok=True)
     torch.save(latent, cache_path)
 
     return latent


### PR DESCRIPTION
error logs:
```
root@autodl-container-123649bdb7-c13475ce:~# bash train.bash
You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers
You are using a model of type clip_text_model to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
You are using a model of type t5 to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
Loading checkpoint shards: 100%|███████████████████████████████| 2/2 [00:01<00:00,  1.68it/s]
Traceback (most recent call last):
  File "/root/./t2i-trainer/train_flux_lora_ui_kontext.py", line 2049, in <module>
    main(args)
  File "/root/./t2i-trainer/train_flux_lora_ui_kontext.py", line 898, in main
    create_empty_embedding(tokenizers,text_encoders)
  File "/root/t2i-trainer/utils/image_utils_flux.py", line 1167, in create_empty_embedding
    torch.save(latent, cache_path)
  File "/root/venv/lib/python3.10/site-packages/torch/serialization.py", line 627, in save
    with _open_zipfile_writer(f) as opened_zipfile:
  File "/root/venv/lib/python3.10/site-packages/torch/serialization.py", line 501, in _open_zipfile_writer
    return container(name_or_buffer)
  File "/root/venv/lib/python3.10/site-packages/torch/serialization.py", line 472, in __init__
    super().__init__(torch._C.PyTorchFileWriter(self.name))
RuntimeError: Parent directory cache does not exist.
```

I checked the ./cache path is correct and exist
and find `File "/root/t2i-trainer/utils/image_utils_flux.py", line 1167, in create_empty_embedding torch.save(latent, cache_path)`  maybe the problem.
add check path exist code:
`os.makedirs(os.path.dirname(cache_path), exist_ok=True)`